### PR TITLE
Add intern job posting

### DIFF
--- a/source/people/intern-2012-cyclus.rst
+++ b/source/people/intern-2012-cyclus.rst
@@ -8,7 +8,7 @@ leading the development of a novel open-source agent-based platform
 for the simulation of advanced nuclear fuel cycles, Cyclus
 (cyclus.github.com).  The core infrastructure of this effort combines
 concepts from operations research, computer science and nuclear
-engineering to provide a flexible basis for studying the tecehnical
+engineering to provide a flexible basis for studying the technical
 and socioeconomic impacts of different nuclear fuel cycle choices.
 
 CNERG is seeking a qualified individual to assist in the development
@@ -26,7 +26,7 @@ Required experience
 ---------------------
 
 * Demonstrated experience with scientific software development
-* Demonstrated knowledge of C++ & python in a linux environment
+* Demonstrated knowledge of C++ & python in a Linux environment
 * Some experience with components of a modern team-based software development processes:
 
     * version control (we use git)


### PR DESCRIPTION
@gidden @rwcarlsen @katyhuff 

I'm planning to expand the search for Cyclus help to include a "Research Intern" - basically a post-doc like position for someone without a PhD.  My draft of the position description, scaled back from the research parts of the Post-Doc announcement, is in this pull request.  It is aimed more at a computer scientist than an engineer (perhaps).

Please consider the following questions in your feedback:
- is an MS important/necessary?  (I am not sure what title I can have for a position that is not a MS, but can investigate)
- are their any skills missing?
- other thoughts?
