### PR TITLE
Update Makefile to match best practice (from svalinn.github.com)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,12 @@ gh-publish:
 	git checkout $(GH_PUBLISH_BRANCH)
 	git checkout $(GH_SOURCE_BRANCH) -- $(GH_SOURCE_DIR)
 	git reset HEAD 
+	make clean
 	make html
 	rsync -a $(BUILDDIR)/* .
+	rsync -a $(BUILDDIR)/.* .
+	git add `(cd $(BUILDDIR); find . -type f; cd ..)`
 	rm -rf $(GH_SOURCE_DIR) $(BUILDDIR)
-	git add -A 
 	git commit -m "Generated $(GH_PUBLISH_BRANCH) for `git log $(GH_SOURCE_BRANCH) -1 --pretty=short --abbrev-commit`" && git push $(GH_UPSTREAM_REPO) $(GH_PUBLISH_BRANCH)
 	git checkout $(GH_SOURCE_BRANCH)
 


### PR DESCRIPTION
This fix will prevent adding extra files during gh-publish.
