### PR TITLE
Updated MOAB link.

### DIFF
--- a/source/projects/main.rst
+++ b/source/projects/main.rst
@@ -107,7 +107,7 @@ research areas are also being pursued by individual CNERG members:
 * application of social-behavioral models of individual agents to study
   :doc:`nuclear material diversion and proliferation issues <cvt>`.
 
-.. _MOAB: http://trac.mcs.anl.gov/projects/ITAPS/wiki/MOAB
+.. _MOAB: http://sigma.mcs.anl.gov/moab-library/
 .. _DAGMC: http://svalinn.github.com/DAGMC
 .. _core technology: http://github.com/cyclus/cyclus
 .. _Cyder: http://github.com/katyhuff/cyder


### PR DESCRIPTION
Updating the link for MOAB to the new sigma site so people are directed to the most recent set of instructions for building/installing MOAB.