### PR TITLE
Support publishing the website with docker 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ docker-gh-stage:
 	rm -rf $(GH_SOURCE_DIR) $(BUILDDIR)
 
 docker-gh-push:
+	git checkout $(GH_PUBLISH_BRANCH)
 	git commit -m "Generated $(GH_PUBLISH_BRANCH) for `git log $(GH_SOURCE_BRANCH) -1 --pretty=short --abbrev-commit`" && git push -f $(GH_UPSTREAM_REPO) $(GH_PUBLISH_BRANCH)
 	git checkout $(GH_SOURCE_BRANCH)
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ help:
 	@echo "  gh-preview to build HTML in directory $BUILDDIR for testing"
 	@echo "  gh-revert  to cleanup HTML build in directory $BUILDDIR after testing"
 	@echo "  gh-publish final build and push from source branch to master branch"
+	@echo "  docker-gh-stage   final build and push from source branch to master branch"
+	@echo "  docker-gh-push    final build and push from source branch to master branch"
 	@echo "  html       to make standalone HTML files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
@@ -65,6 +67,21 @@ gh-publish:
 	rsync -a $(BUILDDIR)/.* .
 	git add `(cd $(BUILDDIR); find . -type f; cd ..)`
 	rm -rf $(GH_SOURCE_DIR) $(BUILDDIR)
+	git commit -m "Generated $(GH_PUBLISH_BRANCH) for `git log $(GH_SOURCE_BRANCH) -1 --pretty=short --abbrev-commit`" && git push -f $(GH_UPSTREAM_REPO) $(GH_PUBLISH_BRANCH)
+	git checkout $(GH_SOURCE_BRANCH)
+
+docker-gh-stage:
+	git checkout $(GH_PUBLISH_BRANCH)
+	git checkout $(GH_SOURCE_BRANCH) -- $(GH_SOURCE_DIR)
+	git reset HEAD 
+	make clean
+	make html
+	rsync -a $(BUILDDIR)/* .
+	rsync -a $(BUILDDIR)/.* .
+	git add `(cd $(BUILDDIR); find . -type f; cd ..)`
+	rm -rf $(GH_SOURCE_DIR) $(BUILDDIR)
+
+docker-gh-push:
 	git commit -m "Generated $(GH_PUBLISH_BRANCH) for `git log $(GH_SOURCE_BRANCH) -1 --pretty=short --abbrev-commit`" && git push -f $(GH_UPSTREAM_REPO) $(GH_PUBLISH_BRANCH)
 	git checkout $(GH_SOURCE_BRANCH)
 

--- a/README.md
+++ b/README.md
@@ -120,3 +120,32 @@ please clone it first):
     ```exit```
 
 5. preview your modified version of the website using your prefered web browser.
+
+Use docker to publish the website
+----------------------------------
+To build CNERG website using docker you can use the cnerg container containing
+all the required dependencies to build the website
+`cnerg/cnerg.github.io-deps`.
+
+This is separated into two steps since this is easier than making your git
+config info available inside the docker container.
+
+From the directory containing the website repository (if you don't have one yet
+please clone it first):
+
+1. run the docker container: 
+
+    ```docker run -u $UID -v $PWD:/local_drive -it cnerg/cnerg.github.io-deps```
+
+2. go into the mounted folder in docker: 
+    ```cd /local_drive```
+
+3. stage the updated website for publication
+    ```make docker-gh-stage```
+
+4. quit docker: 
+    ```exit```
+
+5. publish the updated website
+     ```make docker-gh-push```
+

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ please clone it first):
 
 1. run the docker container: 
 
-    ```docker run -v $PWD:/local_drive -it cnerg/cnerg.github.io-deps```
+    ```docker run -u $UID -v $PWD:/local_drive -it cnerg/cnerg.github.io-deps```
 
 2. go into the mounted folder in docker: 
     ```cd /local_drive```


### PR DESCRIPTION
Since a docker image may not be configured with all of a user's git credentials, this splits up the steps of publishing a website into two - one that uses the docker for Sphinx processing and one that just pushes to master.