### PR TITLE
Link Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+Code of Conduct
+=================
+
+In order to make it available for rendering on the website via Sphinx, this file is located elsewhere.  Please refer to the [Code Of Conduct here](source/codeofconduct.rst).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+source/codeofconduct.rst

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,0 @@
-source/codeofconduct.rst


### PR DESCRIPTION
This adds a link to the CoC from a file that Github expects in order to convince GH that we have a CoC.