### PR TITLE
Adding Biegel coal-to-nuclear GAIN pres.

### DIFF
--- a/_data/presentations.yml
+++ b/_data/presentations.yml
@@ -5,3 +5,10 @@
   url: https://docs.google.com/presentation/d/e/2PACX-1vR0VuXn9tlpcxJFQUMcSb7atU45Qe85LO1dAViA-gCe36JOMXk4AShU1m8RCa3FLEiSs-UvaDmBMfWv/pub
   person: Paul Wilson
   person_dir: pphw
+
+- date: "2022-10-04"
+  venue: Gateway for Accelerated Innovation in Nuclear (GAIN)
+  venue_url: https://gain.inl.gov/SitePages/Home.aspx
+  title: "Investigating Benefits and Challenges of Converting Coal Power Plants to Nuclear Power Plants"
+  person: Katie Biegel
+  person_dir: keb

--- a/_data/presentations.yml
+++ b/_data/presentations.yml
@@ -10,5 +10,6 @@
   venue: Gateway for Accelerated Innovation in Nuclear (GAIN)
   venue_url: https://gain.inl.gov/SitePages/Home.aspx
   title: "Investigating Benefits and Challenges of Converting Coal Power Plants to Nuclear Power Plants"
+  url: https://gain.inl.gov/SitePages/Coal2Nuclear.aspx
   person: Katie Biegel
   person_dir: keb


### PR DESCRIPTION
Adding Biegel presentation for the coal-to-nuclear GAIN webinar to the Presentations page.

The slides will be made publicly available soon, but haven't been released yet. I'll make a separate PR to link the slides when they become available.