### PR TITLE
Add missing package to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,4 @@ source "https://rubygems.org"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 gem "github-pages", group: :jekyll_plugins
+gem "webrick"


### PR DESCRIPTION
Newer versions of the standard jekyll docker image appear to be missing the `webrick` package in the Gemfile.  This just adds it as an explicit dependency.