### PR TITLE
update workflow to newer version for node compatibility

### DIFF
--- a/.github/workflows/fetch_zotero.yml
+++ b/.github/workflows/fetch_zotero.yml
@@ -37,7 +37,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Runs wget to interact with Zotero API
       - name: Fetch publication list from Zotero API


### PR DESCRIPTION
The newer version of the `checkout` action avoids a deprecation of an old version of `node.js`