### PR TITLE
Update lewis profile and add M&C 2023 publications

### DIFF
--- a/community/people/lg/index.md
+++ b/community/people/lg/index.md
@@ -3,29 +3,36 @@ layout: person
 image: lewis.png
 title: Lewis Gross
 role: PhD Candidate, US NRC Fellow
-email: 
+email:
   - ligross@wisc.edu
 room: "428 ERB"
 services:
     github: lewisgross1296
+    linkedin: lewisgross1296
 ---
 
 ## Research Interests
-* Neutronics for shielding and power generation
+* Multiphysics modeling and simulation
+* Neutronics for reactor design
 * Monte Carlo methods for radiation transport
 * Generation IV reactors
 * High Performance Computing
-* Numerical Analysis 
+* Open-Source Software
 
 ## Current Projects
-* [FRENSIE](https://github.com/FRENSIE/FRENSIE) 
+* [Cardinal](https://github.com/neams-th-coe/cardinal) is an Open-Source [MOOSE](https://github.com/idaholab/moose) (Multiphysics Object-Oriented Simulation Environment) Application developed at Argonne National Laboratory and the University of Illinois - Urbana Champaign. I am using it to model the [Virtual Test Bed's Gas Cooled Microreactor](https://mooseframework.inl.gov/virtual_test_bed/microreactors/gcmr/)
+* [OpenMC](https://github.com/openmc-dev/openmc) is an Open-Source Monte Carlo code developed at Argonne National Laboratory. It is one of the tools that interfaces with Cardinal
 
 ## Education
 * University of Wisconsin - Madison, PhD Nuclear Engineering, Current Student
 * University of Wisconsin - Madison, MS Nuclear Engineering, Fall 2020
 * University of Wisconsin - Madison, BS Nuclear Engineering, Certificates in Mathematics and Physics Summer 2018
 
+## Publications
+* [Verification of the Cardinal Multiphysics Solver for 1-D Coupled Heat Transfer and Neutron Transport](https://www.researchgate.net/publication/373173646_Verification_of_the_Cardinal_Multiphysics_Solver_for_1-D_Coupled_Heat_Transfer_and_Neutron_Transport). Lewis Gross, April Novak, Patrick Shriwise, and Paul Wilson
+
 ## Prior Research and Industry Experience
+* Argonne National Lab. Research Aide (Intern), Summer 2022
 * Phoenix, LLC. Nuclear Analysis Intern, Summer 2018
 * Heat and Mass Transfer Group, Undergraduate Researcher under Dr. Raluca Scarlat, Summer 2017 - Spring 2018
 * Musculoskeletal Research Center, Summer Intern under Dr. Savio Woo, Summer 2015


### PR DESCRIPTION
While updating my personal profile, I realized that we should add the recent publications from M&C 2023 to the [Conference Papers](https://cnerg.github.io/pubs/abstracts.html) webpage.

Both @ngranda and I have entries to add, but I wasn't able to figure out where in this repo we add the data for our papers. @gonuke could you please let me know the proper way to add our publications?

Closes #217.