### PR TITLE
fix broken link

### DIFF
--- a/_data/skills.yml
+++ b/_data/skills.yml
@@ -15,7 +15,7 @@
 - title: Literature review
   desc: Finding and carefully reading journal articles helps to build a deeper understanding of our science
   links:
-    - url: https://researchguides.library.wisc.edu/keepingcurrent
+    - url: https://www.library.wisc.edu/steenbock/2023/09/08/keeping-current/
       text: Keeping current in the literature
     - url: https://web.stanford.edu/class/cs244/papers/HowtoReadPaper.pdf
       text: How to Read a Paper


### PR DESCRIPTION
Closes #240. It's possible this link fails at some point in the future, but it works for now. @MicahGale suggested we incorporate a [jekyll link checking step](https://www.supertechcrew.com/jekyll-check-for-broken-links/) into our GitHub Actions. I think this is a good idea but should be punted to another PR to prioritize fixing this link.