### PR TITLE
try new key for pushing

### DIFF
--- a/.github/workflows/fetch_zotero.yml
+++ b/.github/workflows/fetch_zotero.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ZOTERO_BOT_PUSH }}
 
       # Runs wget to interact with Zotero API
       - name: Fetch publication list from Zotero API
@@ -62,5 +64,5 @@ jobs:
       - name: Push changes # push the output folder to your repo
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ZOTERO_BOT_PUSH }}
           force: true


### PR DESCRIPTION
Since I added branch protection the zotero bot can no longer push to main.  This should fix this according to documentation here: https://github.com/ad-m/github-push-action