### PR TITLE
Added Support for open street map.

### DIFF
--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -25,8 +25,8 @@ layout: default
           <a href="{{ page.google_map }}" target=_blank>
             {{ page.address }}</br>
           </a>
-	  {% elsif page.open_street_map != null %}
-	  <a href="{{ page.open_street_map }}" target=_blank>
+          {% elsif page.open_street_map != null %}
+          <a href="{{ page.open_street_map }}" target=_blank>
             {{ page.address }}</br>
           </a>
           {% else %}

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -25,6 +25,10 @@ layout: default
           <a href="{{ page.google_map }}" target=_blank>
             {{ page.address }}</br>
           </a>
+	  {% elsif page.open_street_map != null %}
+	  <a href="{{ page.open_street_map }}" target=_blank>
+            {{ page.address }}</br>
+          </a>
           {% else %}
           {{ page.address }}</br>
           {% endif %}


### PR DESCRIPTION
* Whereas the mission of CNERG includes the development and deployment of open and reliable software tools, and
* Whereas Google Maps software and the underlying GIS data are closed source, and
* Whereas Google has been found to have an monopoly on online search engines, and to have engaged in illegal anti-competitive behaviors, though not in furtherance of Google Maps per se, and
* Whereas OpenStreetMap is open Data licensed under the Open Data Commons Open Database License,
* Therefore, be it resolved that:
   * CNERG stop using Google Maps as a sole provider of GIS data, and
   * CNERG allow the use of OpenStreetMap GIS data.