### PR TITLE
Update expectations from hack-a-thon feedback

### DIFF
--- a/community/manual/expectations.md
+++ b/community/manual/expectations.md
@@ -246,7 +246,7 @@ interactions that are possible in face-to-face meetings are uniquely valuable
 and are likely to provide near term input to your research and professional
 development as well as establish your place in a professional network for the
 long term.  We will work together to identify important and relevant conferences
-and creating ties to other scientists working in your field.  Over time you will
+and create ties to other scientists working in your field.  Over time you will
 become connected to a network of peers and colleagues. Travel to ANS National
 Meetings and Student Conferences can be organized in conjunction with the UW-ANS
 Student Section.

--- a/community/manual/expectations.md
+++ b/community/manual/expectations.md
@@ -236,8 +236,8 @@ their PhD research projects during an internship when early in their plan.
 ### Technical Conferences and Professional Networks
 
 You are encouraged to attend technical conferences to as a way to engage with
-your technical community. We will discuss which conferences make sense for you
-to present your CNERG research with funding from the grants that support that
+your technical community. We will discuss at which conferences make sense for you
+to present your CNERG research, with funding from the grants that support that
 research. You may also identify conferences that are valuable and interesting,
 beyond those for which you will receive financial support. (The Graduate School
 has [programs to request support for travel to

--- a/community/manual/expectations.md
+++ b/community/manual/expectations.md
@@ -50,7 +50,7 @@ opportunity to review your research progress and performance as a researcher
 under the expectations described here.  This will also provide you a time to
 provide feedback to me on my role as an advisor. You will be asked to provide a
 formal report of the following: Your progress during the previous time period,
-including a self-assessment of that work, Your goals for the coming semester, Any
+including a self-assessment of that work, your goals for the coming semester, any
 concerns of frustrations you have with the CNERG community, including myself.
 
 

--- a/community/manual/expectations.md
+++ b/community/manual/expectations.md
@@ -19,6 +19,7 @@ independently on an original contribution to earn your degree.
 
 One of my primary duties is to represent our research group externally by
 * writing proposals for new and innovative research ideas,
+* bringing in financial resources to support research needs,
 * writing journal articles and conference papers,
 * attending meetings and workshops,
 * participating in professional societies, and
@@ -33,9 +34,11 @@ your graduate experience.
 You have a right to the following from me as your advisor:
 * Maintenance/support of your research tools and environment to maximize your
   research progress,
+* Provide financial support to attend conferences to present CNERG research
 * Timely review of your research products,
-* Access to my time to address questions and obstacles to your research,
+* Access to my time to individually address questions and obstacles to your research,
 * Constructive assessment of the quality and progress of your research,
+* Provide guidance for academic progress and plan, 
 * Management of the health of the CNERG community,
 * Flexibility in accommodating individual circumstances, and
 * Opportunities for you to provide feedback on my role as an advisor.
@@ -61,6 +64,12 @@ including milestone dates and deliverables.  Over time you will become
 increasingly responsible for independently defining these goals.  During the
 academic semester, performing well in your courses is certainly important, but
 should not result in a complete lack of research productivity.
+
+Completing a graduate degree should be viewed as a full time professional job,
+with commensurate workload. While CNERG is committed to allowing everyone to
+maintain a healthy work-life balance, and graduate degrees are not awarded for 
+effort alone, the more time spent on your academic and research tasks, the
+more quickly you should be able to graduate.
 
 ### Research Documentation
 
@@ -136,13 +145,23 @@ at times seem as though the work of others is not related to your own, but
 making an effort to understand their work will add creative energy to your own
 work and allow you to recognize the overlaps that are sure to exist.
 
+Most CNERG meetings are setup to allow remote participation, intended for
+specific purposes including participating in meetings while living/working
+remotely or traveling. There may be rare circumstances where you need to work
+from home and choose to participate in a meeting, e.g. deliveries, illness, etc.
+In these situations, you should discuss whether it's appropriate to participate
+remotely in meetings with your advisor. Specifically, in the case of illness,
+please use your own judgment to determine whether you are well enough to
+participate. 
+
 ### Office Hours
 
 Choosing when you will spend time in the office as a professional is a matter of
 finding a balance between your personal lifestyle and work habits and being
 available to your advisor and colleagues for impromptu meetings and
 consultations.  It is therefore necessary to establish some regular work-day
-hours when you can generally be found in your office most days of the week.
+hours, typically including the middle of the day, when you can generally be
+found in your office most days of the week.
 
 ### Working with Scientists
 

--- a/community/manual/expectations.md
+++ b/community/manual/expectations.md
@@ -34,7 +34,7 @@ your graduate experience.
 You have a right to the following from me as your advisor:
 * Maintenance/support of your research tools and environment to maximize your
   research progress,
-* Provide financial support to attend conferences to present CNERG research,
+* Financial support to attend conferences to present CNERG research,
 * Timely review of your research products,
 * Access to my time to individually address questions and obstacles to your research,
 * Constructive assessment of the quality and progress of your research,
@@ -112,17 +112,17 @@ but will not edit or rewrite sections.
 Presenting your work at conferences is an important way to draw attention to
 your contributions and leads to valuable interactions with peers about your
 research.  We will work together to identify the most relevant conferences for
-your work and track the rhythm and deadlines to plan your participation. Both
-oral and poster presentations allow you to attach a personal element to your
-work and convince the audience to learn more about your research through your
-written publications. The quality of the presentations can be important in
-establishing your professional identity.  We will work together to identify the
-most important information to include and the most effective way to present it,
-both in oral and poster presentations. Over time you will become comfortable at
-presenting your work to peers in a variety of formats and environments. You are
-encouraged to submit your work to technical conferences and will receive
-reasonable travel support to present your work.  Travel to ANS Student
-conferences will generally not be supported.
+your work and track the frequency and submission deadlines in order to plan your
+participation. Both oral and poster presentations allow you to attach a personal
+element to your work and convince the audience to learn more about your research
+through your written publications. The quality of the presentations can be
+important in establishing your professional identity.  We will work together to
+identify the most important information to include and the most effective way to
+present it, in both oral and poster presentations. Over time you will become
+comfortable at presenting your work to peers in a variety of formats and
+environments. You are encouraged to submit your work to technical conferences
+and will receive reasonable travel support to present your work.  Travel to ANS
+Student conferences will generally not be supported.
 
 ## Community Interactions
 
@@ -150,19 +150,18 @@ Most CNERG meetings are setup to allow remote participation, intended for
 specific purposes including participating in meetings while living/working
 remotely or traveling. There may be rare circumstances where you need to work
 from home and choose to participate in a meeting, e.g. deliveries, illness, etc.
-In these situations, you should discuss whether it's appropriate to participate
-remotely in meetings with your advisor. Specifically, in the case of illness,
-please use your own judgment to determine whether you are well enough to
-participate. 
+In these situations, you should discuss with me whether it's appropriate to
+participate remotely in meetings. Specifically, in the case of illness, please
+use your own judgment to determine whether you are well enough to participate. 
 
 ### Office Hours
 
 Choosing when you will spend time in the office as a professional is a matter of
 finding a balance between your personal lifestyle and work habits and being
-available to your advisor and colleagues for impromptu meetings and
-consultations.  It is therefore necessary to establish some regular work-day
-hours, typically including the middle of the day, when you can generally be
-found in your office most days of the week.
+available to me and colleagues for impromptu meetings and consultations.  It is
+therefore necessary to establish some regular work-day hours, typically
+including the middle of the day, when you can generally be found in your office
+most days of the week.
 
 ### Software/Code Review
 
@@ -177,9 +176,9 @@ best practices and algorithm design.
 The CNERG community includes scientists and other staff who are a valuable part
 of your support network.  Whether or not they have a formal role in evaluating
 your work, their guidance and input to your work should be considered in the
-same way as guidance and input from your advisor.  Similarly, you should expect
-their role in your research to be similar to that of your advisor, including
-co-authorship on publications, when appropriate.
+same way as guidance and input from me.  Similarly, you should expect their role
+in your research to be similar to that of me, including co-authorship on
+publications, when appropriate.
 
 ### Working with PhD Committees
 
@@ -188,7 +187,7 @@ support your research progress.  While it may be common to select these
 individuals for the expertise that they will bring to evaluating your finished
 work, this same expertise is often useful during the process of completing that
 work.  There are likely to be facets of your research for which those committee
-members can provide more valuable advice than your advisor, and they should be
+members can provide more valuable advice than me, and they should be
 consulted on those topics.  This will both improve the quality of the final work
 and also keep your committee members abreast of your progress, helping them
 better understand your completed work with less effort.
@@ -226,12 +225,12 @@ pursuing.
 
 Students are welcome to pursue internships at companies and national
 laboratories during their graduate studies, but these should be discussed and
-coordinated with their advisor. Important considerations include academic
-milestones, student funding duration, and research deliverables.  As students
-progress in their research, there will be a strong incentive for internships
-to be aligned to their own research efforts to allow them to continue making
-progress during the internship. In some instances, students have identified
-their PhD research projects during an internship when early in their plan.
+coordinated with me. Important considerations include academic milestones,
+student funding duration, and research deliverables.  As students progress in
+their research, there will be a strong incentive for internships to be aligned
+to their own research efforts to allow them to continue making progress during
+the internship. In some instances, students have identified their PhD research
+projects during an internship when early in their plan.
 
 ### Technical Conferences and Professional Networks
 

--- a/community/manual/expectations.md
+++ b/community/manual/expectations.md
@@ -47,7 +47,7 @@ opportunity to review your research progress and performance as a researcher
 under the expectations described here.  This will also provide you a time to
 provide feedback to me on my role as an advisor. You will be asked to provide a
 formal report of the following: Your progress during the previous time period,
-including a self-assessment of that work Your goals for the coming semester Any
+including a self-assessment of that work, Your goals for the coming semester, Any
 concerns of frustrations you have with the CNERG community, including myself.
 
 
@@ -79,11 +79,17 @@ Journal publications are the most important way to share your knowledge and
 creativity with the rest of the scientific community. Students pursuing a
 Masters degree will be expected to author or make major contributions to at
 least one journal paper submission. Students pursuing a doctoral degree will be
-expected to author at least two journal papers submissions.  In many cases,
-these publications will be directly related to your thesis research and will
-contribute to your ability to communicate your final research product. Reviewing
-student writing is one of the most time-consuming and important parts of my job.
-The ability to write well about your research will demonstrate a deep
+expected to author at least two journal papers submissions.  More publications
+are possible depending on how the work progresses, and different career paths
+have different expectations for publications. In many cases, these publications
+will be directly related to your thesis research and will contribute to your
+ability to communicate your final research product. For a Masters student, their
+paper might loosely align with the completion of their thesis.  For a PhD
+student, these publications might loosely align with their Preliminary Exam and
+their defense.
+
+Reviewing student writing is one of the most time-consuming and important parts
+of my job. The ability to write well about your research will demonstrate a deep
 understanding and amplify your scientific successes.  We will work together to
 identify strategies for improving your writing throughout your training.  Over
 time you will become a more independent writer, needing less feedback from me to
@@ -96,16 +102,18 @@ but will not edit or rewrite sections.
 
 Presenting your work at conferences is an important way to draw attention to
 your contributions and leads to valuable interactions with peers about your
-research.  Both oral and poster presentations allow you to attach a personal
-element to your work and convince the audience to learn more about your research
-through your written publications. The quality of the presentations can be
-important in establishing your professional identity.  We will work together to
-identify the most important information to include and the most effective way to
-present it, both in oral and poster presentations. Over time you will become
-comfortable at presenting your work to peers in a variety of formats and
-environments. You are encouraged to submit your work to technical conferences
-and will receive reasonable travel support to present your work.  Travel to ANS
-Student conferences will generally not be supported.
+research.  We will work together to identify the most relevant conferences for
+your work and track the rhythm and deadlines to plan your participation. Both
+oral and poster presentations allow you to attach a personal element to your
+work and convince the audience to learn more about your research through your
+written publications. The quality of the presentations can be important in
+establishing your professional identity.  We will work together to identify the
+most important information to include and the most effective way to present it,
+both in oral and poster presentations. Over time you will become comfortable at
+presenting your work to peers in a variety of formats and environments. You are
+encouraged to submit your work to technical conferences and will receive
+reasonable travel support to present your work.  Travel to ANS Student
+conferences will generally not be supported.
 
 ## Community Interactions
 
@@ -134,7 +142,7 @@ Choosing when you will spend time in the office as a professional is a matter of
 finding a balance between your personal lifestyle and work habits and being
 available to your advisor and colleagues for impromptu meetings and
 consultations.  It is therefore necessary to establish some regular work-day
-hours when you can generally be found in your office.
+hours when you can generally be found in your office most days of the week.
 
 ### Working with Scientists
 
@@ -170,31 +178,35 @@ original contribution.  We will work together to identify the best strategies
 for finding useful and interesting articles.  Over time, you will become
 proficient at finding good quality articles that are relevant to your work.
 Reading other people’s published work will also contribute to improved writing
-skills.  A goal of a detailed reading of one publication per month is a good
+skills.  A goal of a detailed reading of a few publications per month is a good
 minimum standard.
 
 ### Seminars
 
-The Nuclear Engineering & Engineering Physics department conducts a regular seminar series with a wide
-range of topics from all the research areas of the department.  These seminars
-are generally scheduled on Tuesdays at 12 PM and you should receive notification
-from the department office.  All graduate students in the EP department are
-expected to attend these seminars.  While it may be tempting to dismiss some
-topics as unrelated to your work, this is an opportunity to learn about a wide
-variety of interesting research.  More importantly, it is common to find
-connections to your own work, even if they are weak connections, and in so doing
-you will develop a deeper understanding of the work you are pursuing.
+The Nuclear Engineering & Engineering Physics department conducts a regular
+seminar series with a wide range of topics from all the research areas of the
+department.  These seminars are generally scheduled weekly and you should
+receive notification from the department office.  All graduate students in the
+NEEP department are expected to attend these seminars.  While it may be tempting
+to dismiss some topics as unrelated to your work, this is an opportunity to
+learn about a wide variety of interesting research.  More importantly, it is
+common to find connections to your own work, even if they are weak connections,
+and in so doing you will develop a deeper understanding of the work you are
+pursuing.
 
 ### Technical Conferences and Professional Networks
 
-You are encouraged to attend technical conferences even if you are not
-presenting CNERG research, but should not expect to receive financial support.
-The personal interactions that are possible in face-to-face meetings are
-uniquely valuable and are likely to provide near term input to your research and
-professional development as well as establish your place in a professional
-network for the long term.  We will work together to identify important and
-relevant conferences and creating ties to other scientists working in your
-field.  Over time you will become connected to a network of peers and
-colleagues. Travel to ANS National Meetings and Student Conferences can be
-organized in conjunction with the UW-ANS Student Section.
+You are encouraged to attend technical conferences to as a way to engage with
+your technical community. We will discuss which conferences make sense for you
+to present your CNERG research with funding from the grants that support that
+research. You may also identify conferences that are valuable and interesting,
+beyond those for which you will receive financial support. The personal
+interactions that are possible in face-to-face meetings are uniquely valuable
+and are likely to provide near term input to your research and professional
+development as well as establish your place in a professional network for the
+long term.  We will work together to identify important and relevant conferences
+and creating ties to other scientists working in your field.  Over time you will
+become connected to a network of peers and colleagues. Travel to ANS National
+Meetings and Student Conferences can be organized in conjunction with the UW-ANS
+Student Section.
 

--- a/community/manual/expectations.md
+++ b/community/manual/expectations.md
@@ -239,7 +239,9 @@ You are encouraged to attend technical conferences to as a way to engage with
 your technical community. We will discuss which conferences make sense for you
 to present your CNERG research with funding from the grants that support that
 research. You may also identify conferences that are valuable and interesting,
-beyond those for which you will receive financial support. The personal
+beyond those for which you will receive financial support. (The Graduate School
+has [programs to request support for travel to
+conferences.](https://grad.wisc.edu/funding/grants-competition/)) The personal
 interactions that are possible in face-to-face meetings are uniquely valuable
 and are likely to provide near term input to your research and professional
 development as well as establish your place in a professional network for the

--- a/community/manual/expectations.md
+++ b/community/manual/expectations.md
@@ -131,7 +131,8 @@ investment in that community.  The simplest way to contribute is by attending
 group meetings and spending time in your office during common hours.  The
 combination of formal and informal interactions that results from these two
 simple steps creates a sense of familiarity that will directly contribute to our
-combined success.
+combined success. The strength of our community depends on collective 
+commitment to these activities.
 
 ### Meeting Attendance
 
@@ -162,6 +163,14 @@ available to your advisor and colleagues for impromptu meetings and
 consultations.  It is therefore necessary to establish some regular work-day
 hours, typically including the middle of the day, when you can generally be
 found in your office most days of the week.
+
+### Software/Code Review
+
+Review of each other's software is an important activity that contributes both
+to the quality of the software and the development of both the software author
+and software reviewer. Students are expected to regularly review each other's
+software contributions using their own developing knowledge of programming
+best practices and algorithm design.
 
 ### Working with Scientists
 

--- a/community/manual/expectations.md
+++ b/community/manual/expectations.md
@@ -213,6 +213,17 @@ common to find connections to your own work, even if they are weak connections,
 and in so doing you will develop a deeper understanding of the work you are
 pursuing.
 
+### Internships
+
+Students are welcome to pursue internships at companies and national
+laboratories during their graduate studies, but these should be discussed and
+coordinated with their advisor. Important considerations include academic
+milestones, student funding duration, and research deliverables.  As students
+progress in their research, there will be a strong incentive for internships
+to be aligned to their own research efforts to allow them to continue making
+progress during the internship. In some instances, students have identified
+their PhD research projects during an internship when early in their plan.
+
 ### Technical Conferences and Professional Networks
 
 You are encouraged to attend technical conferences to as a way to engage with

--- a/community/manual/expectations.md
+++ b/community/manual/expectations.md
@@ -38,7 +38,7 @@ You have a right to the following from me as your advisor:
 * Timely review of your research products,
 * Access to my time to individually address questions and obstacles to your research,
 * Constructive assessment of the quality and progress of your research,
-* Provide guidance for academic progress and plan, 
+* Guidance for your academic progress and plan, 
 * Management of the health of the CNERG community,
 * Flexibility in accommodating individual circumstances, and
 * Opportunities for you to provide feedback on my role as an advisor.

--- a/community/manual/expectations.md
+++ b/community/manual/expectations.md
@@ -235,13 +235,13 @@ projects during an internship when early in their plan.
 ### Technical Conferences and Professional Networks
 
 You are encouraged to attend technical conferences to as a way to engage with
-your technical community. We will discuss at which conferences make sense for you
+your technical community. We will discuss at which conferences it makes sense for you
 to present your CNERG research, with funding from the grants that support that
 research. You may also identify conferences that are valuable and interesting,
 beyond those for which you will receive financial support. (The Graduate School
 has [programs to request support for travel to
 conferences.](https://grad.wisc.edu/funding/grants-competition/)) The personal
-interactions that are possible in face-to-face meetings are uniquely valuable
+interactions that are possible in face-to-face meetings at conferences are uniquely valuable
 and are likely to provide near term input to your research and professional
 development as well as establish your place in a professional network for the
 long term.  We will work together to identify important and relevant conferences

--- a/community/manual/expectations.md
+++ b/community/manual/expectations.md
@@ -34,7 +34,7 @@ your graduate experience.
 You have a right to the following from me as your advisor:
 * Maintenance/support of your research tools and environment to maximize your
   research progress,
-* Provide financial support to attend conferences to present CNERG research
+* Provide financial support to attend conferences to present CNERG research,
 * Timely review of your research products,
 * Access to my time to individually address questions and obstacles to your research,
 * Constructive assessment of the quality and progress of your research,


### PR DESCRIPTION
This PR updates the expectations document based on feedback and discussion at the January 2025 hack-a-thon.

Fixes #307 

* Update seminar time? Or remove specific time?
* Advisor expectations
   * Funding/support of students (see proposal writing)
   * Support the academic planning (Course advising, quals, etc)
   * “Access to time” for individual
* Internships under Prof Dev & Growth
* Community interaction: code review
* Student expectation: workload expectations
* Meetings - remote participation
* Office hours:
    * 10-3
    * remote work?
* Conferences: link to: https://grad.wisc.edu/funding/grants-competition/


