### PR TITLE
Added Headers, and modified CNERG Software List in Dropdown

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -60,6 +60,8 @@
 - title: "Software"
   url: "/software"
   subcategories:
+    - subheading: "CNERG-Managed"
+      target: "_blank"
     - subtitle: "Svalinn"
       exturl: "https://svalinn.github.io"
       target: "_blank"
@@ -80,9 +82,22 @@
       exturl: "https://fuelcycle.org"
       target: "_blank"
       github: "https://github.com/cyclus/cyclus"
-    - subtitle: "FRENSIE"
-      exturl: "https://github.com/FRENSIE/FRENSIE"
+    - subtitle: divider
+    - subheading: "Affiliates"
       target: "_blank"
+    - subtitle: Cardinal
+      exturl: "https://cardinal.cels.anl.gov/"
+      target: "_blank"
+      github: "https://github.com/neams-th-coe/cardinal"
+    - subtitle: OpenMC
+      exturl: "https://docs.openmc.org"
+      target: "_blank"
+      github: "https://github.com/openmc-dev/openmc"
+    - subtitle: MontePy
+      exturl: "https://www.montepy.org/en/stable/"
+      target: "_blank"
+      github: "https://github.com/idaholab/MontePy"
+
 
 - title: "Upload to CNERG"
   url: "upload.html"

--- a/_includes/site_nav.html
+++ b/_includes/site_nav.html
@@ -12,10 +12,13 @@
                 <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="{{ site.baseurl }}/{{ item.url }}" >{{ item.title }}</a>
                 <div class="dropdown-menu" aria-labelledby="download">
             {% for subcategory in item.subcategories %}
-              {% if subcategory.subtitle == "divider" %}
-              <div class="dropdown-divider"></div>
+              {% if subcategory.subheading != null %}
+                  <div class="dropdown-header">{{ subcategory.subheading }}</div>
               {% else %}
               <div class="dropdown-item">
+              {% if subcategory.subtitle == "divider" %}
+                <div class="dropdown-divider"></div>
+              {% else %}
               {% if subcategory.suburl == null %}
                   <a target="{{ subcategory.target }}" href="{{ subcategory.exturl }}">
                     {% if subcategory.icon != null %}
@@ -35,6 +38,7 @@
                   {% if subcategory.github != null %}
                   <a href="{{ subcategory.github }}" target="_blank"><img class="cnerg-service-menu-icon" src="{{ site.baseurl }}/services/icons/github.svg"></a>
                   {% endif %}
+              {% endif %}
               {% endif %}
               </div>
               {% endif %}


### PR DESCRIPTION
The CENRG Website's software dropdown was both outdated (FRENSIE), and lacking a way to differentiate software that CENRG manages from software that CNERG contributes to, but does not "own". This PR addresses both of these concerns by removing old, unsupported, software (again, FRENSIE), and by adding two headers and a divider to the Software Dropdown (see attached picture).

OLD:
<img width="181" alt="Screenshot 2025-01-15 at 9 53 22 AM" src="https://github.com/user-attachments/assets/bdf3cba2-9869-419c-aa61-8ad2b62d7cdb" />

NEW:
<img width="181" alt="Screenshot 2025-01-15 at 9 51 15 AM" src="https://github.com/user-attachments/assets/19566350-7e4a-460a-9ada-d6045efab683" />

Closes #318 