### PR TITLE
Add chtc links

### DIFF
--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -20,4 +20,4 @@
     - url: https://chtc.cs.wisc.edu/uw-research-computing/hpc/guides.html
       text: "HPC Computing Guides"
     - url: https://docs.google.com/document/d/1Nl1E2jM0z6VLQSe8C2Tbpvm79l9Yxt6pc2PumhwX9is/edit?usp=sharing
-      text: "Tips & Tricks: Using CHTC"
+      text: "Tips & Tricks: Using CHTC (intranet)"

--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -4,7 +4,7 @@
     - url: https://docs.google.com/document/d/11olSnxB78TBg0Tjns4JTMhzFB-jHXBfPPNoaRu-A4Zc/edit
       text: Style Guide for Authoring Papers and Presentations (intranet)
 - title: PEP8
-  desc: style guide for python code
+  desc: Style guide for python code
   links:
     - url: https://www.python.org/dev/peps/pep-0008/
       text: PEP8 Style Guide
@@ -13,3 +13,11 @@
   links:
     - url: https://docs.google.com/document/d/1-6e7QAhklcXMxr3H05808iVopLy65atuhBNH7cvUCyY/edit
       text: "How to: Travel with the UW (intranet)"
+- title: How to use CHTC
+  desc: Resources on for making use of Center for High Throughput Computing (CHTC) at UW-Madison
+    - url: https://chtc.cs.wisc.edu/uw-research-computing/htc/guides.html
+      text: "HTC Computing Guides"
+    - url: https://chtc.cs.wisc.edu/uw-research-computing/hpc/guides.html
+      text: "HPC Computing Guides"
+    - url: https://docs.google.com/document/d/1Nl1E2jM0z6VLQSe8C2Tbpvm79l9Yxt6pc2PumhwX9is/edit?usp=sharing
+      text: "Tips & Tricks: Using CHTC"

--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -15,6 +15,7 @@
       text: "How to: Travel with the UW (intranet)"
 - title: CHTC
   desc: Resources for using the Center for High Throughput Computing (CHTC) at UW-Madison
+  links:
     - url: https://chtc.cs.wisc.edu/uw-research-computing/htc/guides.html
       text: "HTC Computing Guides"
     - url: https://chtc.cs.wisc.edu/uw-research-computing/hpc/guides.html

--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -13,8 +13,8 @@
   links:
     - url: https://docs.google.com/document/d/1-6e7QAhklcXMxr3H05808iVopLy65atuhBNH7cvUCyY/edit
       text: "How to: Travel with the UW (intranet)"
-- title: How to use CHTC
-  desc: Resources on for making use of Center for High Throughput Computing (CHTC) at UW-Madison
+- title: CHTC
+  desc: Resources for using the Center for High Throughput Computing (CHTC) at UW-Madison
     - url: https://chtc.cs.wisc.edu/uw-research-computing/htc/guides.html
       text: "HTC Computing Guides"
     - url: https://chtc.cs.wisc.edu/uw-research-computing/hpc/guides.html


### PR DESCRIPTION
Adding in links for using HPC and HTC to the website and also linked tips and tricks document.