### PR TITLE
updated events page to be past events, added the 2025 CENRG Hackathon

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,5 +1,2 @@
-- title: Codenames Online Social
-  desc: Gather online to play Codenames
-  links:
-    - url: 
-      text: Link TBD
+- title: 2025 CNERG Hackathon (13 Jan, 2025 - 16 Jan, 2025)
+  desc: A week long documentation and group-oriented project event

--- a/community/events.md
+++ b/community/events.md
@@ -1,9 +1,7 @@
 ---
 layout: desc_list
-title: Upcoming Events
+title: Past CNERG Events
 data: events
 ---
-
-<h1>UNDER DEVELOPMENT</h1>
 
 


### PR DESCRIPTION
Pretty self explanatory, just made it so the events page listed Past events, and populated it with a real event.

Closes #270 