### PR TITLE
Update roster for Spring 2025

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -7,10 +7,6 @@
   - name: "Dr. Tim Bohm"
     url: "tdb"
     role: "Scientist"
-  - name: "Ben Nibbelink"
-    url: "bn"
-    role: "Software Developer"
-    image: bn.jpg
   - name: "Dr. Enrique Miralles-Dolz"
     url: "emd"
     role: "Visiting Researcher"
@@ -18,10 +14,6 @@
 
 - group: 'Graduate Students'
   people:
-  - name: "Katie Mummah"
-    url: "kam"
-    role: "PhD Dissertator"
-    image: mummah.jpg
   - name: "Katie Biegel"
     url: "keb"
     image: biegel.jpg
@@ -68,10 +60,6 @@
     image: walid.jpeg
 - group: 'Undergraduate Students'
   people:
-  - name: "Bowen Quan"
-    url: "bq"
-    role: "Undergraduate Researcher"
-    image: Bowen_Quan.jpg
   - name: "Damian Jilk"
     url: "dj"
     role: "Undergraduate Intern"
@@ -84,37 +72,35 @@
     url: "ew"
     role: "Undergraduate Intern"
     image: EitanHeadshot.jpg
-  - name: "Syn Hubbard"
-    url: "synh"
-    role: "Undergraduate Researcher"
-    image: synh.png
 
 - group: 'Alumni and Former CNERG members'
   people:
   - name: Tae Wook Ahn
-    url:
+    url: https://www.linkedin.com/in/taewook-ahn/
     year: 2010
     role: MS
     employer: Constellation
-    employer_url: http://www.constellationenergy.com/
+    employer_url: https://www.constellationenergy.com/
   - name: Marina Arabidze
     year: 2011
     role: MS - Environment and Resources
     employer: BP
+    url: https://www.linkedin.com/in/marina-arabidze-7b025024/
   - name: Elliott Biondo
-    url:
+    url: https://www.ornl.gov/staff-profile/elliott-d-biondo
     year: 2016
     role: PhD
     employer: Oak Ridge National Laboratory
-    employer_url: http://www.ornl.gov
+    employer_url: https://www.ornl.gov
   - name: Philip Britt
     url: https://www.linkedin.com/in/philip-britt-aa1a2b1b6/
     year: 2021
     role: PhD
     employer: TerraPower
     employer_url: https://www.terrapower.com/
+    url: https://www.linkedin.com/in/philip-britt-aa1a2b1b6/
   - name: Goeff Bull
-    url:
+    url: https://www.linkedin.com/in/geoffreyrbull/
     year: 2005
     role: MS
     employer: US Army
@@ -139,36 +125,36 @@
     year: 2021
     role: MS
     employer: UW-Madison
-    employer_url: http://reti.ep.wisc.edu
+    employer_url: https://reti.ep.wisc.edu
   - name: Andrew Davis
     url:
     year: 2012-2017
     role: Scientist
     employer: Culham Centre for Fusion Energy
-    employer_url: http://www.ccfe.ac.uk
+    employer_url: https://www.ccfe.ac.uk
   - name: Chelsea D'Angelo
     year: 2019
     role: PhD
     employer: Los Alamos National Laboratory
-    employer_url: http://www.lanl.gov
+    employer_url: https://www.lanl.gov
   - name: Kerry (Dunn) Bossler
     url:
     year: 2014
     role: PhD
     employer: Sandia National Laboratories
-    employer_url: http://www.sandia.gov
+    employer_url: https://www.sandia.gov
   - name: Eric Edwards
     url:
     year: 2007
     role: PhD
-    employer: Shine Medical Technologies
-    employer_url: http://shinemed.com
+    employer: SHINE Technologies
+    employer_url: https://shinefusion.com
   - name: Matthew Gidden
-    url: http://www.mattgidden.com
+    url: https://www.mattgidden.com
     year: 2015
     role: PhD
     employer: IIASA
-    employer_url: http://iiasa.ac.at
+    employer_url: https://iiasa.ac.at
   - name: Ryan Grady
     url:
     year: 2008
@@ -186,29 +172,27 @@
     employer: Oak Ridge National Laboratory
     employer_url: https://www.ornl.gov
   - name: Louis Hartono
-    url:
     year: 2020
     role: Research Intern
-    employer:
-    employer_url:
   - name: Chris Hoffman
-    url:
     year: 2017
     role: MS
     employer: DNV
     employer_url:
   - name: Po Hu
-    url:
     year: 2008
     role: PhD
     employer: Shanghai Jiaotong University
     employer_url:
+  - name: "Syn Hubbard"
+    role: Research Intern
+    year: 2023-2024
   - name: Katy Huff
-    url: http://katyhuff.github.io
+    url: https://katyhuff.github.io
     year: 2013
     role: PhD
     employer: University of Illinois
-    employer_url: http://npre.illinois.edu
+    employer_url: https://npre.illinois.edu
   - name: Shai'Anthony Huff
     year: 2021
     role: Undergraduate intern
@@ -233,6 +217,8 @@
   - name: "Lucas Jacobson"
     role: MS
     year: 2018
+    employer: SHINE Technologies
+    employer_url: https://shinefusion.com
   - name: C Grace Kelly
     year: 2021
     role: Undergraduate intern
@@ -241,13 +227,13 @@
     year: 2021
     role: MS
     employer: Bates White Consulting
-    employer_url: http://www.bateswhite.com/
+    employer_url: https://www.bateswhite.com/
   - name: Brian Kiedrowski
-    url: http://www.engin.umich.edu/ners/people/faculty/brian-kiedrowski
+    url: https://www.engin.umich.edu/ners/people/faculty/brian-kiedrowski
     year: 2009
     role: PhD
     employer: University of Michigan
-    employer_url: http://ners.engin.umich.edu
+    employer_url: https://ners.engin.umich.edu
   - name: Kalin R. Kiesling
     role: PhD
     year: 2022
@@ -266,6 +252,7 @@
     employer_url: https://navalnuclearlab.energy.gov/
   - name: "Kenneth Lee"
     role: "Undergraduate Intern"
+    year: 2022-2023
   - name: Piper Lincoln
     url: https://www.linkedin.com/in/piperlincoln
     year: 2020
@@ -277,7 +264,7 @@
     year: 2014-2017
     role: Scientist
     employer: Lawrence Livermore National Laboratory
-    employer_url: http://www.llnl.gov
+    employer_url: https://www.llnl.gov
   - name: Courtlan McLay
     url:
     year: 2015
@@ -289,7 +276,7 @@
     year: 2011
     role: MS
     employer: Kinetrics
-    employer_url: http://www.kinectrics.com/
+    employer_url: https://www.kinectrics.com/
   - name: Baptiste Mouginot
     url: https://www.linkedin.com/in/baptiste-mouginot-75992520/
     year: 2015-2021
@@ -300,7 +287,18 @@
     year: 2021
     role: Undergraduate Intern
     employer: UW-Madison
-    employer_url: http://reti.ep.wisc.edu
+    employer_url: https://reti.ep.wisc.edu
+  - name: "Katie Mummah"
+    year: 2025
+    role: PhD
+    url: https://nuclearkatie.com
+    employer: Los Alamos National Lab
+    employer_url: https://www.lanl.gov
+  - name: "Ben Nibbelink"
+    year: 2023-2024
+    role: "Software Developer"
+    employer: SAS
+    employer_url: https://sas.com
   - name: Erik Nygaard
     url:
     year: 2011
@@ -308,7 +306,7 @@
     employer: BWXT Technologies
     employer_url: https://www.bwxt.com/
   - name: Kyle Oliver
-    url: http://www.kyleoliver.net
+    url: https://www.kyleoliver.net
     year: 2009
     role: MS
     employer: Learning Forte
@@ -326,7 +324,7 @@
     year: 2007
     role: PhD
     employer: Thai Office of Atoms for Peace
-    employer_url: http://www.oaep.go.th/index_en.php
+    employer_url: https://www.oaep.go.th/index_en.php
   - name: Eliot Pickhardt
     url:
     year: 2021
@@ -343,12 +341,15 @@
     role: Undergraduate Intern
     year: 2022
     employer: University of Southern California
+  - name: "Bowen Quan"
+    role: "Undergraduate Researcher"
+    year: 2022-2024
   - name: Tracy Radel
     url: https://www.linkedin.com/pub/tracy-radel/24/6b7/538
     year: 2007
     role: MS
-    employer: Shine Medical Technologies
-    employer_url: http://www.shinemed.com
+    employer: US Nuclear Regulatory Commission
+    employer_url: https://www.nrc.gov
   - name: Olzhas Rakhimov
     url:
     year: 2014
@@ -356,17 +357,17 @@
     employer:
     employer_url:
   - name: Eric Relson
-    url: http://hackaday.io/hacker/614-gertlex
+    url: https://hackaday.io/hacker/614-gertlex
     year: 2013
     role: MS
     employer: Zebra Technologies
-    employer_url: http://www.zebra.com/
+    employer_url: https://www.zebra.com/
   - name: Jeremy Roberts
-    url: http://www.mne.ksu.edu/people/roberts
+    url: https://www.mne.ksu.edu/people/roberts
     year: 2009
     role: MS
     employer: Kansas State University
-    employer_url: http://www.kse.edu
+    employer_url: https://www.kse.edu
   - name: Josh Ruegsegger
     year: 2022
     role: MS
@@ -381,13 +382,13 @@
     year: 2009
     role: BS Engineering Physics
     employer: National Renewable Energy Laboratory
-    employer_url: http://www.nrel.gov
+    employer_url: https://www.nrel.gov
   - name: Lane Schultz
-    url:
+    url: https://www.linkedin.com/in/lane-schultz-983920236/
     year: 2017
     role: Research Intern
-    employer:
-    employer_url:
+    employer: Sandia National Laboratories
+    employer_url: https://www.sandia.gov
   - name: Anthony Scopatz
     url:
     year: 2013-2015
@@ -413,17 +414,17 @@
     employer: Argonne National Laboratory
     employer_url: https://www.anl.gov
   - name: Stuart Slattery
-    url: http://www.csm.ornl.gov/newsite/cees.html
+    url: https://www.csm.ornl.gov/newsite/cees.html
     year: 2013
     role: PhD
     employer: Oak Ridge National Laboratory
-    employer_url: http://www.ornl.gov
+    employer_url: https://www.ornl.gov
   - name: Rachel Slaybaugh
     url: https://www.nuc.berkeley.edu/people/rachel-slaybaugh
     year: 2012
     role: PhD
     employer: DCVC
-    employer_url: http://www.dcvc.com/
+    employer_url: https://www.dcvc.com/
   - name: Brandon Smith
     year: 2011
     role: PhD
@@ -439,7 +440,7 @@
     year: 2006
     role: MS
     employer: Constellation
-    employer_url: http://www.constellationenergy.com/
+    employer_url: https://www.constellationenergy.com/
   - name: Samuel Stern
     url:
     year: 2019
@@ -451,7 +452,7 @@
     year: 2023
     role: PhD
     employer: Oak Ridge National Laboratory
-    employer_url: http://www.ornl.gov
+    employer_url: https://www.ornl.gov
   - name: Alex Swenson
     url:
     year: 2019
@@ -487,7 +488,7 @@
     year: 2017-2019
     role: Visiting Student Researcher
     employer: Hefei Institutes of Physical Science, Chinese Academy of Sciences
-    employer_url: http://english.hf.cas.cn/
+    employer_url: https://english.hf.cas.cn/
 
 
 

--- a/_data/people.yml
+++ b/_data/people.yml
@@ -76,7 +76,7 @@
 - group: 'Alumni and Former CNERG members'
   people:
   - name: Tae Wook Ahn
-    url: https://www.linkedin.com/in/taewook-ahn/
+    linkedin: https://www.linkedin.com/in/taewook-ahn/
     year: 2010
     role: MS
     employer: Constellation
@@ -85,28 +85,29 @@
     year: 2011
     role: MS - Environment and Resources
     employer: BP
-    url: https://www.linkedin.com/in/marina-arabidze-7b025024/
+    linkedin: https://www.linkedin.com/in/marina-arabidze-7b025024/
   - name: Elliott Biondo
     url: https://www.ornl.gov/staff-profile/elliott-d-biondo
+    linkedin: https://www.linkedin.com/in/elliottbiondo/
     year: 2016
     role: PhD
     employer: Oak Ridge National Laboratory
     employer_url: https://www.ornl.gov
   - name: Philip Britt
-    url: https://www.linkedin.com/in/philip-britt-aa1a2b1b6/
+    linkedin: https://www.linkedin.com/in/philip-britt-aa1a2b1b6/
     year: 2021
     role: PhD
     employer: TerraPower
     employer_url: https://www.terrapower.com/
-    url: https://www.linkedin.com/in/philip-britt-aa1a2b1b6/
+    linkedin: https://www.linkedin.com/in/philip-britt-aa1a2b1b6/
   - name: Goeff Bull
-    url: https://www.linkedin.com/in/geoffreyrbull/
+    linkedin: https://www.linkedin.com/in/geoffreyrbull/
     year: 2005
     role: MS
     employer: US Army
     employer_url:
   - name: Drew Buys
-    url:
+    linkedin: https://www.linkedin.com/in/drew-buys-288931162/
     year: 2017
     role: Project Assistant
     employer: Booz Allen Hamilton
@@ -115,19 +116,19 @@
     year: 2021
     role: Researcher
   - name: Robert Carlsen
-    url:
+    linkedin: https://www.linkedin.com/in/robert-carlsen-67072718/
     year: 2016
     role: PhD
-    employer: Canonical
-    employer_url: https://canonical.com/
+    employer: Coreform
+    employer_url: https://coreform.com
   - name: Ryan Dailey
-    url: 
+    linkedin: https://www.linkedin.com/in/ryan-dailey-4b2295127/
     year: 2021
     role: MS
     employer: UW-Madison
     employer_url: https://reti.ep.wisc.edu
   - name: Andrew Davis
-    url:
+    linkedin: https://www.linkedin.com/in/andrew-davis-4690271b/
     year: 2012-2017
     role: Scientist
     employer: Culham Centre for Fusion Energy
@@ -144,29 +145,32 @@
     employer: Sandia National Laboratories
     employer_url: https://www.sandia.gov
   - name: Eric Edwards
-    url:
+    linkedin: https://www.linkedin.com/in/eric-edwards-phd-b00963135/
     year: 2007
     role: PhD
     employer: SHINE Technologies
     employer_url: https://shinefusion.com
   - name: Matthew Gidden
-    url: https://www.mattgidden.com
+    linkedin: https://www.linkedin.com/in/matthew-gidden-11a6366/
     year: 2015
     role: PhD
-    employer: IIASA
-    employer_url: https://iiasa.ac.at
-  - name: Ryan Grady
-    url:
+    employer: Pacific Northwest National Laboratory
+    employer_url: https://www.pnnl.gov
+  - name: Ryan (Grady) Grayson
+    linkedin: https://www.linkedin.com/in/rymgrayson/
     year: 2008
     role: MS
     employer: NorthStar Medical
     employer_url: https://www.northstarnm.com/
   - name: Nancy Granda-Duarte
+    linkedin: https://www.linkedin.com/in/nancy-granda-duarte-50b8b8104/
     role: PhD
     year: 2024
     employer: Commonwealth Fusion Systems
     employer_url: https://cfs.energy
   - name: Moataz Harb
+    linkedin: https://www.linkedin.com/in/moataz-harb-539090136/
+    url: https://www.ornl.gov/staff-profile/moataz-s-harb
     role: PhD
     year: 2019
     employer: Oak Ridge National Laboratory
@@ -174,11 +178,13 @@
   - name: Louis Hartono
     year: 2020
     role: Research Intern
+    linkedin: https://www.linkedin.com/in/louishartono/
+    employer: Slimstock
   - name: Chris Hoffman
     year: 2017
     role: MS
     employer: DNV
-    employer_url:
+    linkedin: https://www.linkedin.com/in/chris-hoffman-36633457/
   - name: Po Hu
     year: 2008
     role: PhD
@@ -187,27 +193,30 @@
   - name: "Syn Hubbard"
     role: Research Intern
     year: 2023-2024
+    linkedin: https://www.linkedin.com/in/synh/
   - name: Katy Huff
     url: https://katyhuff.github.io
     year: 2013
     role: PhD
     employer: University of Illinois
     employer_url: https://npre.illinois.edu
+    linkedin: https://www.linkedin.com/in/katyhuff/
   - name: Shai'Anthony Huff
     year: 2021
     role: Undergraduate intern
   - name: Paul Humrickhouse
-    url:
+    url: https://www.ornl.gov/staff-profile/paul-w-humrickhouse
     year: 2005
     role: MS
     employer: Oak Ridge National Laboratory
     employer_url: https://www.ornl.gov
   - name: Ahmad Ibrahim
-    url: https://www.linkedin.com/pub/ahmad-ibrahim/13/585/161
+    linkedin: https://www.linkedin.com/pub/ahmad-ibrahim/13/585/161
     year: 2012
     role: PhD
     employer: Oak Ridge National Laboratory
     employer_url: https://www.ornl.gov
+    url: https://www.ornl.gov/staff-profile/ahmad-m-ibrahim
   - name: Steven Jackson
     url:
     year: 2013
@@ -219,48 +228,58 @@
     year: 2018
     employer: SHINE Technologies
     employer_url: https://shinefusion.com
+    linkedin: https://www.linkedin.com/in/lucas-jacobson-b777a465/
   - name: C Grace Kelly
     year: 2021
     role: Undergraduate intern
+    linkedin: https://www.linkedin.com/in/c-grace-kelly-b9542b180/
   - name: Anatara Khadria
     url:
+    linkedin: https://www.linkedin.com/in/antara-khadria-030175b6/
     year: 2021
     role: MS
-    employer: Bates White Consulting
-    employer_url: https://www.bateswhite.com/
+    employer: Georgetown Climate Center
+    employer_url: https://www.georgetownclimate.org/
   - name: Brian Kiedrowski
     url: https://www.engin.umich.edu/ners/people/faculty/brian-kiedrowski
+    linkedin: 
     year: 2009
     role: PhD
     employer: University of Michigan
     employer_url: https://ners.engin.umich.edu
   - name: Kalin R. Kiesling
+    url: https://www.anl.gov/profile/kalin-kiesling
     role: PhD
     year: 2022
     employer: Argonne National Laboratory
     employer_url: https://www.anl.gov
+    linkedin:  https://www.linkedin.com/in/kalin-kiesling-32921951/
   - name: Matthew Klebenow
-    url:
+    linkedin: https://www.linkedin.com/in/klebenowm/
     year: 2013
     role: BS Engineering Physics
     employer: EPIC Systems
-    employer_url:
+    employer_url: https://www.epic.com/
   - name: Bradly Laufenberg
+    linkedin: https://www.linkedin.com/in/bradly-laufenberg-48b541171/
     year: 2021
     role: BS Nuclear Engineering
-    employer: Naval Nuclear Laboratory
-    employer_url: https://navalnuclearlab.energy.gov/
+    employer: Framatome
+    employer_url: https://www.framatome.com
   - name: "Kenneth Lee"
     role: "Undergraduate Intern"
     year: 2022-2023
+    linkedin: https://www.linkedin.com/in/kenneth-nagase-lee/
+    employer: Global Power Components
   - name: Piper Lincoln
-    url: https://www.linkedin.com/in/piperlincoln
+    linkedin: https://www.linkedin.com/in/piperlincoln
     year: 2020
     role: BS Engineering Mechanics
     employer: General Dynamics Mission Systems
     employer_url:
   - name: Meghan McGarry
     url:
+    linkedin: https://www.linkedin.com/in/meghan-m-8806476a/
     year: 2014-2017
     role: Scientist
     employer: Lawrence Livermore National Laboratory
@@ -272,26 +291,27 @@
     employer:
     employer_url:
   - name: Damien Moule
-    url:
+    linkedin: https://www.linkedin.com/in/damien-moule-41a69012a/
     year: 2011
     role: MS
     employer: Kinetrics
     employer_url: https://www.kinectrics.com/
   - name: Baptiste Mouginot
-    url: https://www.linkedin.com/in/baptiste-mouginot-75992520/
+    linkedin: https://www.linkedin.com/in/baptiste-mouginot-75992520/
     year: 2015-2021
     role: Scientist
     employer: BaM Scientific Consulting
-    employer_url:  
   - name: Matthew Nyberg
     year: 2021
     role: Undergraduate Intern
     employer: UW-Madison
     employer_url: https://reti.ep.wisc.edu
+    linkedin: https://www.linkedin.com/in/matthew-n-727a8011a/
   - name: "Katie Mummah"
     year: 2025
     role: PhD
     url: https://nuclearkatie.com
+    linkedin: https://www.linkedin.com/in/nuclearkatie/
     employer: Los Alamos National Lab
     employer_url: https://www.lanl.gov
   - name: "Ben Nibbelink"
@@ -299,71 +319,70 @@
     role: "Software Developer"
     employer: SAS
     employer_url: https://sas.com
+    linkedin: https://www.linkedin.com/in/ben-nibbelink/
   - name: Erik Nygaard
-    url:
+    linkedin: https://www.linkedin.com/in/erik-nygaard-60868535/
     year: 2011
     role: MS
     employer: BWXT Technologies
     employer_url: https://www.bwxt.com/
   - name: Kyle Oliver
     url: https://www.kyleoliver.net
+    linkedin: https://www.linkedin.com/in/kyle-matthew-oliver/
     year: 2009
     role: MS
-    employer: Learning Forte
-    employer_url: https://learningforte.com/
+    employer: Church Divinity School of the Pacific
+    employer_url: https://cdsp.edu/
   - name: Arrielle Opotowsky
     year: 2021
     role: PhD
+    linkedin: https://www.linkedin.com/in/aopotowsky/
     employer: TerraPower
     employer_url: https://www.terrapower.com
   - name: "Young Hui Park"
     year: 2021
     role: MS
   - name: Phiphat Phruksarojanakun
-    url:
     year: 2007
     role: PhD
     employer: Thai Office of Atoms for Peace
-    employer_url: https://www.oaep.go.th/index_en.php
+    employer_url: https://www.oap.go.th/en/hometh-english/
   - name: Eliot Pickhardt
-    url:
+    linkedin: https://www.linkedin.com/in/eliot-pickhardt/
     year: 2021
     role: Undergraduate Intern
     employer:
     employer_url:
   - name: Michael Priaulx
-    url:
     year: 2008
     role: MS
-    employer:
-    employer_url:
   - name: Yuehan Qin
     role: Undergraduate Intern
     year: 2022
     employer: University of Southern California
-  - name: "Bowen Quan"
-    role: "Undergraduate Researcher"
+    linkedin: https://www.linkedin.com/in/yuehan-qin-845071176/
+  - name: Bowen Quan
+    role: Undergraduate Researcher
     year: 2022-2024
   - name: Tracy Radel
-    url: https://www.linkedin.com/pub/tracy-radel/24/6b7/538
+    linkedin: https://www.linkedin.com/pub/tracy-radel/24/6b7/538
     year: 2007
     role: MS
     employer: US Nuclear Regulatory Commission
     employer_url: https://www.nrc.gov
   - name: Olzhas Rakhimov
-    url:
     year: 2014
     role: Research Intern
-    employer:
-    employer_url:
   - name: Eric Relson
+    linkedin: https://www.linkedin.com/in/eric-relson-5384a712/
     url: https://hackaday.io/hacker/614-gertlex
     year: 2013
     role: MS
     employer: Zebra Technologies
     employer_url: https://www.zebra.com/
   - name: Jeremy Roberts
-    url: https://www.mne.ksu.edu/people/roberts
+    url: https://www.mne.k-state.edu/about/people/faculty/roberts/
+    linkedin: https://www.linkedin.com/in/jeremy-roberts-ba8a99147/
     year: 2009
     role: MS
     employer: Kansas State University
@@ -372,55 +391,56 @@
     year: 2022
     role: MS
   - name: Ben Schmitt
-    url:
+    linkedin: https://www.linkedin.com/in/benjamin-schmitt-79518677/
     year: 2006
     role: MS
-    employer: Global Nuclear Fuels
-    employer_url:
+    employer: Framatome
+    employer_url: https://www.framatome.com
   - name: Andy Scholbrock
-    url:
+    linkedin: https://www.linkedin.com/in/andrew-scholbrock-88810131/
     year: 2009
     role: BS Engineering Physics
     employer: National Renewable Energy Laboratory
     employer_url: https://www.nrel.gov
   - name: Lane Schultz
-    url: https://www.linkedin.com/in/lane-schultz-983920236/
+    linkedin: https://www.linkedin.com/in/lane-schultz-983920236/
     year: 2017
     role: Research Intern
     employer: Sandia National Laboratories
     employer_url: https://www.sandia.gov
   - name: Anthony Scopatz
-    url:
+    linkedin: https://www.linkedin.com/in/scopatz/
     year: 2013-2015
     role: Scientist
     employer: Citadel
     employer_url: https://www.citadel.com
   - name: Owen Selles
-    url:
+    linkedin: https://www.linkedin.com/in/oaselles/
     year: 2017
     role: Project Assistant
     employer: New Jersey Highlands Council
-    employer_url: https://www.nj.gov/dep/
+    employer_url: https://www.nj.gov/njhighlands/
   - name: Tim Setter
-    url:
+    linkedin: https://www.linkedin.com/in/tim-setter-55225492/
     year: 2007
     role: MS
-    employer: Tennessee Valley Authority
-    employer_url:
+    employer: Rus-Set Farms, LLC
   - name: Patrick Shriwise
-    url: https://pshriwise.github.io
+    url: https://www.anl.gov/profile/patrick-c-shriwise
+    linkedin: https://www.linkedin.com/in/patrick-shriwise-682a23176/
     year: 2018
     role: PhD
     employer: Argonne National Laboratory
     employer_url: https://www.anl.gov
   - name: Stuart Slattery
-    url: https://www.csm.ornl.gov/newsite/cees.html
+    url: https://www.ornl.gov/staff-profile/stuart-r-slattery
     year: 2013
     role: PhD
     employer: Oak Ridge National Laboratory
     employer_url: https://www.ornl.gov
   - name: Rachel Slaybaugh
-    url: https://www.nuc.berkeley.edu/people/rachel-slaybaugh
+    url: https://www.dcvc.com/team/rachel-slaybaugh/
+    linkedin: https://www.linkedin.com/in/rslaybaugh/
     year: 2012
     role: PhD
     employer: DCVC
@@ -428,6 +448,7 @@
   - name: Brandon Smith
     year: 2011
     role: PhD
+    linkedin: https://www.linkedin.com/in/brandon-smith-7a1136235/
     employer: Los Alamos National Laboratory
     employer_url: https://www.lanl.gov
   - name: Patrick Snouffer
@@ -435,56 +456,52 @@
     role: MS
     employer: Zeno Power
     employer_url: https://www.zenopower.com/
+    linkedin: https://www.linkedin.com/in/patrick-snouffer-p-e-5948a511/
   - name: Chris Staum
-    url:
+    linkedin: https://www.linkedin.com/in/christopher-staum-29362246/
     year: 2006
     role: MS
     employer: Constellation
     employer_url: https://www.constellationenergy.com/
   - name: Samuel Stern
-    url:
+    linkedin: https://www.linkedin.com/in/sam-stern-693813122/
     year: 2019
     role: BS Engineering Physics
     employer: Accuray
     employer_url: https://www.accuray.com/
   - name: Jordan Stomps
     url: https://www.ornl.gov/staff-profile/jordan-r-stomps
+    linkedin: https://www.linkedin.com/in/jordan-stomps-556912b8/
     year: 2023
     role: PhD
     employer: Oak Ridge National Laboratory
     employer_url: https://www.ornl.gov
   - name: Alex Swenson
-    url:
+    linkedin: https://www.linkedin.com/in/alex-swenson-b5045769/
     year: 2019
     role: MS
     employer: GE-Hitachi
     employer_url: https://nuclear.gepower.com/
   - name: Zach Welch
-    url:
+    linkedin: https://www.linkedin.com/in/zach-welch-35b0a359/
     year: 2013-2015
     role: Research Support
     employer: Amazon
     employer_url: https://aboutamazon.com
   - name: Ellis Wilson
-    url:
     year: 2018
     role: BS Engineering Physics
-    employer:
-    employer_url:
   - name: John Xia
-    url:
     year: 2014-2015
     role: Researcher
-    employer:
-    employer_url:
   - name: Juie Zachman
-    url:
+    linkedin: https://www.linkedin.com/in/jzachman/
     year: 2013-2015
     role: Programmer
     employer: University of Wisconsin-Madison
     employer_url: https://www.wisc.edu
   - name: Xiaokang Zhang
-    url:
+    linkedin: https://www.linkedin.com/in/xiaokang-zhang-33748a160/
     year: 2017-2019
     role: Visiting Student Researcher
     employer: Hefei Institutes of Physical Science, Chinese Academy of Sciences

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -15,9 +15,12 @@ layout: default
         {% for person in group.people %}
         <li>
           {% if person.url != null %}
-          <a href="{{ person.url }}" target="_blank">{{ person.name }}</a>,
+          <a href="{{ person.url }}" target="_blank">{{ person.name }}</a>
           {% else %}
-          {{ person.name }},
+          {{ person.name }}
+          {% endif %}
+          {% if person.linkedin != null %}
+          <a href="{{ person.linkedin }}" target="_blank"><img class="cnerg-service-icon" src="{{ site.baseurl }}/services/icons/linkedin.png" alt="icon for linkedin"></a>
           {% endif %}
           ({{ person.role }}, {{ person.year }}), 
           {% if person.employer != null %}


### PR DESCRIPTION
This moves some names around to update the current roster

* move alumni and departed staff 
* add Linkedin logo/link for each alumni/former members
* add Linkedin data for each alumni/former member
* update employment for many people
* update URLs for some people